### PR TITLE
Update build settings for new Android Studio + Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta7'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.novoda:bintray-release:0.5.0'
     }
     // Workaround for the following test coverage issue. Remove when fixed:

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.novoda:bintray-release:0.5.0'
+        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.novoda:bintray-release:0.8.0'
     }
     // Workaround for the following test coverage issue. Remove when fixed:
     // https://code.google.com/p/android/issues/detail?id=226070

--- a/constants.gradle
+++ b/constants.gradle
@@ -19,7 +19,7 @@ project.ext {
     minSdkVersion = 14
     compileSdkVersion = 26
     targetSdkVersion = 26
-    buildToolsVersion = '26.0.2'
+    buildToolsVersion = '27.0.3'
     testSupportLibraryVersion = '0.5'
     supportLibraryVersion = '26.1.0'
     dexmakerVersion = '1.2'

--- a/constants.gradle
+++ b/constants.gradle
@@ -18,7 +18,7 @@ project.ext {
     // by the library requires API level 16 or greater.
     minSdkVersion = 14
     compileSdkVersion = 26
-    targetSdkVersion = 25
+    targetSdkVersion = 26
     buildToolsVersion = '26.0.2'
     testSupportLibraryVersion = '0.5'
     supportLibraryVersion = '26.1.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/javadoc_library.gradle
+++ b/javadoc_library.gradle
@@ -20,8 +20,6 @@ android.libraryVariants.all { variant ->
         description = "Generates Javadoc for the ${javadocTitle}."
         title = "ExoPlayer ${javadocTitle}"
         source = variant.javaCompile.source
-        classpath = files(variant.javaCompile.classpath.files,
-	                  project.android.getBootClasspath())
         options {
             links "http://docs.oracle.com/javase/7/docs/api/"
             linksOffline "https://developer.android.com/reference",
@@ -30,6 +28,10 @@ android.libraryVariants.all { variant ->
         }
         exclude "**/BuildConfig.java"
         exclude "**/R.java"
+        doFirst {
+            classpath = files(variant.javaCompile.classpath.files,
+                    project.android.getBootClasspath())
+        }
         doLast {
             copy {
                 from "src/main/javadoc"


### PR DESCRIPTION
ExoPlayer had a problem in one of its gradle scripts that prevented builds with the current version of Gradle. Copied the changes to our branch and tested with the main app. (hold this PR until after QA, though).

More info:

https://github.com/google/ExoPlayer/commit/13592dfb53ec99ce1fdb2744e34717dbdec9dea8

